### PR TITLE
Fix time formatting in async/sync demos

### DIFF
--- a/more-python-for-beginners/09 - Asynchronous programming/async_demo.py
+++ b/more-python-for-beginners/09 - Asynchronous programming/async_demo.py
@@ -29,6 +29,6 @@ async def main():
 
         # Print our results
         elapsed_time = default_timer() - start_time
-        print(f'The operation took {elapsed_time:.2} seconds')
+        print(f'The operation took {elapsed_time:.2f} seconds')
 
 asyncio.run(main())

--- a/more-python-for-beginners/09 - Asynchronous programming/sync_demo.py
+++ b/more-python-for-beginners/09 - Asynchronous programming/sync_demo.py
@@ -13,7 +13,7 @@ def run_demo():
     three_data = load_data(3)
 
     elapsed_time = default_timer() - start_time
-    print(f'The operation took {elapsed_time:.2} seconds')
+    print(f'The operation took {elapsed_time:.2f} seconds')
 
 def main():
     run_demo()


### PR DESCRIPTION
## Summary
- use `:.2f` for decimal seconds in async_demo
- use `:.2f` for decimal seconds in sync_demo

## Testing
- `python -m py_compile "more-python-for-beginners/09 - Asynchronous programming/async_demo.py" "more-python-for-beginners/09 - Asynchronous programming/sync_demo.py"`

------
https://chatgpt.com/codex/tasks/task_e_68420f64a2ac832f8898f32c7c1bb1c1